### PR TITLE
Fixes Maven publications to use `upmc-enterprises-graceful-shutdown-s…

### DIFF
--- a/autoconfiguration/build.gradle.kts
+++ b/autoconfiguration/build.gradle.kts
@@ -8,7 +8,6 @@ dependencyManagement {
   }
 }
 
-val archivesBaseName = "upmc-enterprises-graceful-shutdown-spring-boot-autoconfiguration"
 
 dependencies {
   compileOnly("org.springframework.boot:spring-boot-starter-actuator")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ subprojects {
           }
         }
         afterEvaluate {
-          artifactId = project.base.archivesName.get()
+          artifactId = "upmc-enterprises-graceful-shutdown-spring-boot-${project.base.archivesName.get()}"
           version = if (project.hasProperty("release")) version else "$version-SNAPSHOT"
         }
         pom {

--- a/starter/build.gradle.kts
+++ b/starter/build.gradle.kts
@@ -1,5 +1,3 @@
-val archivesBaseName = "upmc-enterprises-graceful-shutdown-spring-boot-starter"
-
 dependencies {
   implementation(project(":autoconfiguration"))
 }


### PR DESCRIPTION
…pring-boot-` as the `artifactId`'s prefix

For example, the following subprojects would use the listed `artifactId` in Maven:
* `starter` -> `upmc-enterprises-graceful-shutdown-spring-boot-starter`
* `autoconfiguration` -> `upmc-enterprises-graceful-shutdown-spring-boot-autoconfiguration`